### PR TITLE
Removed trailing `/site` from nightlies update-sites

### DIFF
--- a/_includes/download-box.txt
+++ b/_includes/download-box.txt
@@ -1,13 +1,16 @@
 <div class="download-section">
+  {% unless fullDownloadUrl %}
+    {% capture fullDownloadUrl %}{{ downloadUrl }}/site{% endcapture %}
+  {% endunless %}
   <div id="{{ divId }}" class="download-link" title="URL Copied To Clipboard" data-content="To install the Scala IDE for Eclipse 3.7 (Indigo), open Eclipse, go to 'Help > Install New Software', and paste this URL into the dialog box. Then, follow the on-screen instructions from there.">
-    {{ downloadUrl }}/site
+    {{ fullDownloadUrl }}
   </div>
   <script type="text/javascript" charset="utf-8">
     $(window).load(function() {
 
       var clip = new ZeroClipboard.Client();
       clip.setHandCursor( true );
-      clip.setText("{{ downloadUrl }}/site");
+      clip.setText("{{ fullDownloadUrl }}");
       clip.glue("{{ divId }}");
 
     });
@@ -23,3 +26,4 @@
 </div>
 
 {% assign zipUrl = nil %}
+{% assign fullDownloadUrl = nil %}

--- a/download/nightly.md
+++ b/download/nightly.md
@@ -24,7 +24,7 @@ Scala IDE Lithium will target Eclipse 4.2 (Juno), but the transition has not bee
 #### For Scala 2.10.x
 
 {% assign divId = 'download-40-210' %}
-{% assign downloadUrl = 'http://download.scala-ide.org/nightly-scala-ide-4.0.x-210x' %}
+{% assign fullDownloadUrl = 'http://download.scala-ide.org/nightly-scala-ide-4.0.x-210x' %}
 {% assign zipUrl = 'http://download.scala-ide.org/nightly-scala-ide-4.0.x-210x.zip' %}
 
 {% include download-box.txt %}
@@ -40,7 +40,7 @@ The Scala IDE 3.0.x build contains fixes to be included in future maintenance re
 #### For Scala 2.10.x
 
 {% assign divId = 'download-30-210' %}
-{% assign downloadUrl = 'http://download.scala-ide.org/nightly-scala-ide-3.0.x-210x' %}
+{% assign fullDownloadUrl = 'http://download.scala-ide.org/nightly-scala-ide-3.0.x-210x' %}
 {% assign zipUrl = 'http://download.scala-ide.org/nightly-scala-ide-3.0.x-210x.zip' %}
 
 {% include download-box.txt %}
@@ -59,7 +59,7 @@ If you are using Eclipse 3.8 or Eclipse 4.2, codename Juno, make sure to install
 
 #### For Scala 2.10.x
 {% assign divId = 'download-30-210-juno' %}
-{% assign downloadUrl = 'http://download.scala-ide.org/nightly-scala-ide-juno-210x' %}
+{% assign fullDownloadUrl = 'http://download.scala-ide.org/nightly-scala-ide-juno-210x' %}
 {% assign zipUrl = 'http://download.scala-ide.org/nightly-scala-ide-juno-210x.zip' %}
 
 {% include download-box.txt %}


### PR DESCRIPTION
Our nightlies update-sites don't follow the same convention of the ecosystem
update-sites. In particular, nightlies update-sites don't have a trailing
`site`.

With the intent of avoiding duplication, I've added a new variable
`fullDownloadUrl` in `download-box.txt`. `fullDownloadUrl` is the actual
update-site url getting displayed in the produced html page.
