### PR TITLE
Renamed Blog into News

### DIFF
--- a/_includes/topbar.txt
+++ b/_includes/topbar.txt
@@ -14,10 +14,10 @@
 	        	<li><a href="{{ site.baseurl }}/download/nightly.html">Nightlies</a></li>
 	      	</ul>
 		</li>
-        <li><a href="{{ site.baseurl }}/blog">Blog</a></li>
+        <li><a href="{{ site.baseurl }}/blog">News</a></li>
         <li><a href="{{ site.baseurl }}/team.html">Team</a></li>
         <li><a href="{{ site.baseurl }}/docs/dev/roadmap.html">Roadmap</a></li>
-      </ul>	
+      </ul>
     </div>
   </div>
 </div>

--- a/blog/index.md
+++ b/blog/index.md
@@ -1,6 +1,6 @@
 ---
 layout: blog-index
-title: Blog
+title: News
 ---
 
 ## [{{ site.posts.first.title }}]({{ site.posts.first.url }})


### PR DESCRIPTION
- The blog is solely used to announce releases, hence it is more accurate to
  name it News.
- I didn't change the folder from `blog` to `news` otherwise all existing links
  would be broken.
