### PR TITLE
Fix typo in version 4.0.0 M1 download link

### DIFF
--- a/_includes/frontpage.txt
+++ b/_includes/frontpage.txt
@@ -24,7 +24,7 @@
 <div>
 		<div class="rounded-corner-box" style="min-height: 0px; float: left; padding: 10px; margin-top: 10px; width: 778px; background-color: rgba(0,0,0,0.5);">
 			<span class="news-box-text">
-				Or... Walk on the wild side. <span class="emphasize"><a href="{{ site.baseurl }}/download/milestone.htmll#scala-ide-400-milestone-1">Try version 4.0.0 M1!</a></span>
+				Or... Walk on the wild side. <span class="emphasize"><a href="{{ site.baseurl }}/download/milestone.html#scala-ide-400-milestone-1">Try version 4.0.0 M1!</a></span>
 			</span>
 		</div>
 		<span class="news-arrow"><img src="{{ site.baseurl }}/resources/images/news-arrow.png"></span>


### PR DESCRIPTION
Just fixed a typo in the download link for the version 4.0.0 M1 in the frontpage.
