### PR TITLE
Adds the links to the 3.0.4 bundles

### DIFF
--- a/_includes/sdk-download-box-2-11.txt
+++ b/_includes/sdk-download-box-2-11.txt
@@ -1,0 +1,47 @@
+<div class="download-section">
+
+<div id="download-link-2-11" class="download-link">
+<a href="#" id="downloadIDE211">
+    Download SDK
+    <small></small>
+</a>
+</div>
+
+<script type="text/javascript">
+var osTuple = [];
+if (navigator.appVersion.indexOf("Win")!=-1) osTuple =          ["Windows - 64 bit" , "http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-win32.win32.x86_64.zip"];
+else if (navigator.appVersion.indexOf("Mac")!=-1) osTuple =     ["Mac - 64 bit"     , "http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-macosx.cocoa.x86_64.zip"];
+else if (navigator.appVersion.indexOf("X11")!=-1) osTuple =     ["Linux - 64 bit"   , "http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-linux.gtk.x86_64.tar.gz"];
+else if (navigator.appVersion.indexOf("Linux")!=-1) osTuple =   ["Linux - 64 bit"   , "http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-linux.gtk.x86_64.tar.gz"];
+else $("#downloadIDE211").hide();
+$("#downloadIDE211").attr("href", osTuple[1]).find("small").html(osTuple[0]);
+</script>
+
+<div class="row">
+  <div class="span4 offset1">
+    <div>
+      <h4 class="inline">Windows</h4>
+    </div>
+    <a href="http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-win32.win32.x86_64.zip">Windows 64 bit</a>
+    <br/>
+    <a href="http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-win32.win32.x86.zip">Windows 32 bit</a>
+  </div>
+  <div class="span4">
+    <div>
+      <h4 class="inline">Mac</h4>
+    </div>
+    <a href="http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-macosx.cocoa.x86_64.zip">Mac OS X Cocoa 64 bit</a>
+    <br/>
+    <a href="http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-macosx.cocoa.x86.zip">Mac OS X Cocoa 32 bit</a>
+  </div>
+  <div class="span4">
+    <div>
+      <h4 classs="inline">Linux</h4>
+    </div>
+    <a href="http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-linux.gtk.x86_64.tar.gz">Linux GTK 64 bit</a>
+    <br/>
+    <a href="http://downloads.typesafe.com/scalaide-pack/3.0.4.vfinal-211-20140421/scala-SDK-3.0.4-2.11-2.11-linux.gtk.x86.tar.gz">Linux GTK 32 bit</a>
+  </div>
+</div>
+
+</div>

--- a/_includes/sdk-download-content.txt
+++ b/_includes/sdk-download-content.txt
@@ -3,9 +3,9 @@
     <h2>Content</h2>
     <ul>
       <li>Eclipse 4.3.1 (Kepler)</li>
-      <li>Scala IDE 3.0.3</li>
+      <li>Scala IDE 3.0.3/3.0.4</li>
       <li>Scala Worksheet 0.2.3</li>
-      <li>Play Framework support 0.4.3</li>
+      <li>Play Framework support 0.4.3 (Scala 2.10 only)</li>
       <li>m2eclipse-scala Maven connector 0.4.3</li>
       <li>access to the full Scala IDE ecosystem</li>
     </ul>

--- a/download/sdk.md
+++ b/download/sdk.md
@@ -11,9 +11,9 @@ Whether you are a seasoned Scala developer, or just picking up the language, thi
 
 {% include sdk-download-content.txt %}
 
-# 3.0.3 Release
+# 3.0.3/3.0.4 Release
 
-This release is available for *Scala 2.10*,
+This release is available for *Scala 2.10* and *Scala 2.11*,
 and is based on *Eclipse 4.3 (Kepler)*.
 
 ### Requirements
@@ -21,6 +21,9 @@ and is based on *Eclipse 4.3 (Kepler)*.
 
 ## For Scala 2.10.x
 {% include sdk-download-box-2-10.txt %}
+
+## For Scala 2.11.x
+{% include sdk-download-box-2-11.txt %}
 
 ## Get Started
 


### PR DESCRIPTION
By popular demand, adds the links to the bundles for Scala IDE 3.0.4 on Scala 2.11.0.
This doesn't make our download pages less confusing.

cc @lutzh @hseeberger
