### PR TITLE
Reorders our download pages to put 2.11 above 2.10 offers

### DIFF
--- a/download/current.md
+++ b/download/current.md
@@ -26,17 +26,17 @@ The 3.0.4 release provides the same features as 3.0.3, but the code was updated 
 ### Requirements
 {% include requirements-juno-kepler.txt %}
 
-#### For Scala 2.10.4
-
-{% assign divId = 'download-210-juno' %}
-{% assign downloadUrl = 'http://download.scala-ide.org/sdk/helium/e38/scala210/stable' %}
-
-{% include download-box.txt %}
-
 #### For Scala 2.11.1
 
 {% assign divId = 'download-211-juno' %}
 {% assign downloadUrl = 'http://download.scala-ide.org/sdk/helium/e38/scala211/stable' %}
+
+{% include download-box.txt %}
+
+#### For Scala 2.10.4
+
+{% assign divId = 'download-210-juno' %}
+{% assign downloadUrl = 'http://download.scala-ide.org/sdk/helium/e38/scala210/stable' %}
 
 {% include download-box.txt %}
 
@@ -101,7 +101,7 @@ Scala 2.10, we recommend you to use the [3.0.0 release](#300_release)
 
 * Eclipse, including the JDT. "Eclipse Classic" is sufficient, but [any Eclipse package can be used][eclipse-package-to-use].
 
-	* Both [Eclipse 3.6 (Helios)][eclipse-helios] and [Eclipse 3.7 (Indigo)][eclipse-indigo] are supported.
+        * Both [Eclipse 3.6 (Helios)][eclipse-helios] and [Eclipse 3.7 (Indigo)][eclipse-indigo] are supported.
 
 [jdk5]: http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase5-419410.html
 [jdk6]: http://www.oracle.com/technetwork/java/javasebusiness/downloads/java-archive-downloads-javase6-419409.html

--- a/download/nightly.md
+++ b/download/nightly.md
@@ -20,14 +20,6 @@ title: Download the Latest Nightly Build
 
 * Scala IDE Lithium works with [Eclipse 4.2][juno] and [4.3][kepler] ([Juno][juno] and [Kepler][kepler]).
 
-#### For Scala 2.10.x
-
-{% assign divId = 'download-40-210' %}
-{% assign fullDownloadUrl = 'http://download.scala-ide.org/nightly-scala-ide-4.0.x-210x' %}
-{% assign zipUrl = 'http://download.scala-ide.org/nightly-scala-ide-4.0.x-210x.zip' %}
-
-{% include download-box.txt %}
-
 #### For Scala 2.11.1
 
 {% assign divId = 'download-40-211' %}
@@ -36,6 +28,13 @@ title: Download the Latest Nightly Build
 
 {% include download-box.txt %}
 
+#### For Scala 2.10.x
+
+{% assign divId = 'download-40-210' %}
+{% assign fullDownloadUrl = 'http://download.scala-ide.org/nightly-scala-ide-4.0.x-210x' %}
+{% assign zipUrl = 'http://download.scala-ide.org/nightly-scala-ide-4.0.x-210x.zip' %}
+
+{% include download-box.txt %}
 
 ## [Eclipse Luna][luna] (upcoming release)
 

--- a/download/sdk.md
+++ b/download/sdk.md
@@ -19,11 +19,11 @@ and is based on *Eclipse 4.3 (Kepler)*.
 ### Requirements
 {% include jdk-requirements-kepler.txt %}
 
-## For Scala 2.10.4
-{% include sdk-download-box-2-10.txt %}
-
 ## For Scala 2.11.1
 {% include sdk-download-box-2-11.txt %}
+
+## For Scala 2.10.4
+{% include sdk-download-box-2-10.txt %}
 
 ## Get Started
 


### PR DESCRIPTION
At the "architectures in the wild" session where our webpage is
getting massively railed on. 

The order of the offers w.r.t versions of Scala putting 2.10 above
2.11 didn't make sense and this was an easily fixable one.
